### PR TITLE
Fix stuff

### DIFF
--- a/expoff.py
+++ b/expoff.py
@@ -30,18 +30,26 @@ def exponential_fuckoff(*dargs, **dkwargs):
     return decorator
 
 
+class WrapCallable:
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+
 class RecursiveMethod:
     def __init__(self, func):
         self.func = func
 
     def __call__(self, *args, **kwargs):
         result = self.func(*args, **kwargs)
-        while callable(result):
+        while isinstance(result, WrapCallable):
             result = result()
         return result
 
     def call(self, *args, **kwargs):
-        return lambda: self.func(*args, **kwargs)
+        return WrapCallable(lambda: self.func(*args, **kwargs))
 
 
 class Retry:

--- a/expoff.py
+++ b/expoff.py
@@ -20,7 +20,7 @@ def exponential_fuckoff(*dargs, **dkwargs):
         @six.wraps(func)
         def wrapped(*args, **kwargs):
             retry = Retry(func, **retry_kwargs)
-            return retry.run()
+            return retry.run(*args, **kwargs)
 
         return wrapped
 

--- a/expoff.py
+++ b/expoff.py
@@ -31,18 +31,17 @@ def exponential_fuckoff(*dargs, **dkwargs):
 
 
 class RecursiveMethod:
-    def __init__(self, obj, func):
+    def __init__(self, func):
         self.func = func
-        self.obj = obj
 
     def __call__(self, *args, **kwargs):
-        result = self.func(self.obj, *args, **kwargs)
+        result = self.func(*args, **kwargs)
         while callable(result):
             result = result()
         return result
 
     def call(self, *args, **kwargs):
-        return lambda: self.func(self.obj, *args, **kwargs)
+        return lambda: self.func(*args, **kwargs)
 
 
 class Retry:
@@ -53,7 +52,7 @@ class Retry:
         for attr, value in kwargs.items():
             setattr(self, attr, value)
 
-        self.run = RecursiveMethod(self, self.run)
+        self.run = RecursiveMethod(self.run)
 
     def run(self, *args, **kwargs):
         try:


### PR DESCRIPTION
Had to do this to get it working for me.

First you've neglected to pass the args to the final callable.

Second, the final callable keeps getting the Retry object as the first argument, and it keeps building up for each call (fifth call you will get five times the Retry object). Second commit fixes this. (At least, based on my tests.)

Third, if you actually want to return a callable the loop `while callable(result): ...` is going to ruin your day. E.g.

``` python
@exponential_fuckoff
def get_int():
    return int

result = get_int()  # Here, result is 0, because int() returns 0
```

Therefore create a wrapper object around the lambda that you can identify instead.
